### PR TITLE
Load 'config' module from current working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ParentText Pipeline
 
-Public repository to handle the process for producing final RapidPro flows from data held in Google Sheets.
+Handles the process for producing RapidPro flows from data held in Google Sheets.
 
 # Setup
 
@@ -9,9 +9,15 @@ Public repository to handle the process for producing final RapidPro flows from 
 3. Install Node and npm LTS versions
 4. Install Node dependencies: `npm install`
 
-# Running pipeline
+# Run
 
-The file `pipelines.py` contains the general functions that can be used to run the pipeline.
+To start the pipeline:
+
+```
+python -m parenttext_pipeline.cli
+```
+
+You will need to create a file called 'config.py', in the current working directory, and define a callable called 'create_config' that returns the pipeline settings as a dict. More details can be in the [configuration page].
 
 # RapidPro flow importer
 
@@ -35,3 +41,5 @@ import_definition(
     definition_file,
 )
 ```
+
+[configuration page]: docs/configuration.md

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,149 @@
+# Configuration
+
+The pipeline is configured via a user-defined callable named `create_config` in a file called 'config.py'.
+
+```python
+def create_config():
+    return {
+        # Config settings here...
+    }
+```
+
+On initialisation, the pipeline will look for this file in the current working directory, load it, then attempt to call `create_config` to generate the configuration settings.
+
+The `create_config` callable must return a `dict` of configuration settings.
+
+# Available settings
+
+## sources
+
+### sources.filename
+
+The name prefix that will be used in filenames during processing.
+
+### sources.spreadsheet\_ids
+
+IDs of Google Sheets where the ParentText flows are defined.
+
+### sources.crowdin\_name
+
+Name of the file that is produced to send to translators.
+
+### sources.tags
+
+Used to identify flows to be process. Possible values for tag 1:
+
+- onboarding
+- dev\_assess
+- ltp_activity
+- home\_activity\_checkin
+- module
+- goal\_checkin
+- safeguarding
+- menu
+- delivery
+
+### sources.split\_no
+
+The number of files into which the final flow definition will be split.
+
+Used to divide the file at the final step to get it to a manageable size that can be uploaded to RapidPro.
+
+## special\_expiration
+
+Used to modify expiration times.
+
+## default\_expiration
+
+Used to modify expiration times.
+
+## model
+
+Name of the Python module containing data models to use as part of the process of converting data extracted from sheets.
+
+## languages
+
+A list of language definitions that will be looked for to localize back into the flows. Each language definition consists of:
+
+- `language`: 3-letter language code used in RapidPro
+- `code`: 2-letter code used in CrowdIn
+
+## translation\_repo
+
+Location of a git repository where translations are stored.
+
+## folder\_within\_repo
+
+The location within `tranlsation_repo` where translations are stored.
+
+Used in conjuction with `translation_repo`, above.
+
+## outputpath
+
+Destination path for all files (including intermediary files and log files).
+
+Default is 'output' within the current workin directory.
+
+## qr\_treatment
+
+How to process "quick replies". Valid values are:
+
+- move: Remove quick replies and add equivalents to them to the message text, and give numerical prompts to allow basic phone users to use the app.
+- reformat: Reformat quick replies so that long ones are added to the message text, as above.
+- none: Do nothing.
+
+## select\_phrases
+
+The default phrase we want to add if quick replies are being moved to message text.
+
+## add\_selectors
+
+If `qr_treatment` is 'move', add some basic numerical quick replies back in. Valid values are 'yes' or 'no'.
+
+## special\_words
+
+Path to a file containing words we always want to keep as full quick replies.
+
+## count\_threshold
+
+When `qr_treatment` is 'reformat', set limits on the number of quick replies that are processed.
+
+If the number of quick replies is below or equal to count\_threshold then the quick replies are left in place.
+
+## length\_threshold
+
+When `qr_treatment` is 'reformat', set limits on the number of quick replies that are processed.
+
+If the character-length of the longest quick reply is below or equal to length\_threshold then the quick replies are left in place.
+
+## ab\_testing\_sheet\_id
+
+Google Sheets ID for Sheet containing AB testing data.
+
+## localisation\_sheet\_id
+
+Google Sheets ID.
+
+## eng\_edits\_sheet\_id
+
+Google Sheets ID for Sheet containing dict edits data.
+
+## transl\_edits\_sheet\_id
+
+Google Sheets ID.
+
+## sg\_flow\_id
+
+Sheets ID for Sheet containing safeguarding data.
+
+## sg\_flow\_name
+
+???
+
+## sg\_path
+
+Path to file containing translated safeguarding words.
+
+## redirect\_flow\_names
+
+Names of redirect flows to be modified as part of safeguarding process.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ authors = [
     {name = "IDEMS International", email = "communications@idems.international"},
 ]
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = {text = "GPL-3.0-or-later"}
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -20,7 +20,6 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/src/parenttext_pipeline/cli.py
+++ b/src/parenttext_pipeline/cli.py
@@ -1,0 +1,24 @@
+import runpy
+
+from parenttext_pipeline.pipelines import Config, run
+
+
+class ConfigError(Exception):
+    pass
+
+
+def init():
+    run(load_config())
+
+
+def load_config():
+    create_config = runpy.run_path('config.py').get("create_config")
+
+    if create_config and callable(create_config):
+        return Config(**create_config())
+    else:
+        raise ConfigError("Could not find 'create_config' function in 'config.py'")
+
+
+if __name__ == '__main__':
+    init()


### PR DESCRIPTION
Provides a way to easily start a run of the pipeline.

A file called config.py is required in the current working directory and the file must contain a function (or callable) called `create_config` that returns a `dict` with configuration settings.

With the config file in place, the pipeline can be started with:

```
python -m parenttext_pipeline.cli
```

I have also modified the README to reflect this, and added documentation about the available configuration settings in a separate document.

This change is backwards-compatible.

Resolves #14 