### PR TITLE
Correct CSV sheet reader usage

### DIFF
--- a/src/parenttext_pipeline/pipelines.py
+++ b/src/parenttext_pipeline/pipelines.py
@@ -429,7 +429,7 @@ def load_sheets(config, source, archive_fp):
             shutil.unpack_archive(archive_fp, temp_dir)
             flows = create_flows(
                 [
-                    os.path.join(temp_dir, spreadsheet_id, "content_index.csv")
+                    os.path.join(temp_dir, spreadsheet_id)
                     for spreadsheet_id in spreadsheet_ids
                 ],
                 None,


### PR DESCRIPTION
Changes in the Toolkit mean that the CSV sheet reader does not read individual CSV files anymore, but reads a directory containing CSVs (a workbook), where each CSV file is considered a sheet in the workbook.