### PR TITLE
Refactor local source references

### DIFF
--- a/src/parenttext_pipeline/configs.py
+++ b/src/parenttext_pipeline/configs.py
@@ -143,6 +143,9 @@ class SheetsSourceConfig(SourceConfig):
     # Path or URL to a zip archive containing folders
     # each with sheets in CSV format (no nesting)
     files_archive: str = None
+    # Path relative to which other paths in the files_list/dict are,
+    # assuming no files_archive is provided
+    basepath: str = None
 
 
 @dataclass(kw_only=True)

--- a/src/parenttext_pipeline/pull_data.py
+++ b/src/parenttext_pipeline/pull_data.py
@@ -83,6 +83,14 @@ def pull_translations(config, source, source_name):
                 )
 
 
+def get_json_from_sheet_id(source, temp_dir, sheet_id):
+    if source.subformat == "google_sheets":
+        return convert_to_json(sheet_id, source.subformat)
+    else:
+        sheet_path = os.path.join(temp_dir, sheet_id)
+        return convert_to_json(sheet_path, source.subformat)
+
+
 def pull_sheets(config, source, source_name):
     # Download all sheets used for flow creation and edits and store as json
     source_input_path = get_input_subfolder(
@@ -91,27 +99,26 @@ def pull_sheets(config, source, source_name):
 
     jsons = {}
     if source.files_archive is not None:
-        if source.subformat != "csv":
-            raise NotImplementedError(
-                "files_archive only supported for sheets of subformat csv."
+        if source.subformat == "google_sheets":
+            raise ValueError(
+                "files_archive not supported for sheets of subformat google_sheets."
             )
         location = source.archive
         archive_filepath = download_archive(config.temppath, location)
-        with tempfile.TemporaryDirectory() as temp_dir:
-            shutil.unpack_archive(archive_filepath, temp_dir)
-            for sheet_id in source.files_list:
-                csv_folder = os.path.join(temp_dir, sheet_id)
-                jsons[sheet_id] = convert_to_json([csv_folder], source.subformat)
+        temp_dir = tempfile.TemporaryDirectory()
+        shutil.unpack_archive(archive_filepath, temp_dir)
     else:
-        for sheet_name in source.files_list:
-            if source.subformat != "google_sheets":
-                raise NotImplementedError(
-                    "files_list only supported for sheets of subformat google_sheets."
-                )
-            sheet_id = get_sheet_id(config, sheet_name)
-            jsons[sheet_name] = convert_to_json(sheet_id, source.subformat)
-    for new_name, sheet_id in source.files_dict.items():
-        jsons[new_name] = convert_to_json(sheet_id, source.subformat)
+        temp_dir = Path(source.basepath or ".")
+
+    for sheet_name in source.files_list:
+        sheet_id = get_sheet_id(config, sheet_name)
+        jsons[sheet_name] = get_json_from_sheet_id(source, temp_dir, sheet_id)
+    for new_name, sheet_name in source.files_dict.items():
+        sheet_id = get_sheet_id(config, sheet_name)
+        jsons[new_name] = get_json_from_sheet_id(source, temp_dir, sheet_id)
+
+    if source.files_archive is not None:
+        temp_dir.cleanup()
 
     for sheet_name, content in jsons.items():
         with open(source_input_path / f"{sheet_name}.json", "w", encoding='utf-8') as export:


### PR DESCRIPTION
Streamline how local files can be referenced as source sheets. Previously, only certain combinations of formats and lists/dicts worked.

To test, create a folder `csv` with a subfolder `safeguarding` and put some csv files inside. Then use the configuration below as `config.json` (it also references the `xlsx` files within this repository). Only invoke `pull_data`.

Note that `files_dict` key or `files_list` entries may not contain certain special characters such as `/`, as they are used as filenames. To reference a list of file paths, you'll need to either need to have all files in the same folder and specify a `basepath`, or use the `sheet_names` dict. 

Question: Because the storage filenames (after running `pull_data`) are determined by the `files_list` entries, should we automatically append `.xlsx` and `.json` (for the respective subformats) so these file endings don't have to be specified in the list? This way we avoid storage filenames ending in `.xlsx.json` `.json.json`.

Note: I haven't tested this on any existing deployments, @edmoss345 could you please check that it doesn't break anything? I also haven't tested `zip` archives (with the `files_archive` config option). @edmoss345 I don't remember where you had an example use case, maybe you can test this or refer me to that `zip` file. Are there any deployments where this is in use currently?

```
{
    "meta": {
        "version": "1.0.0",
        "pipeline_version": "1.0.0"
    },
    "parents": {},
    "flows_outputbasename": "parenttext_all",
    "output_split_number": 1,
    "sheet_names" : {
        "csv_safeguarding" : "csv/safeguarding",
        "xlsx_safeguarding" : "excel_files/safeguarding crisis.xlsx"
    },
    "sources": {
        "safeguarding_csv_dict": {
            "parent_sources": [],
            "format": "sheets",
            "subformat": "csv",
            "files_dict": {
                "safeguarding": "csv/safeguarding"
            }
        },
        "safeguarding_csv_list": {
            "parent_sources": [],
            "format": "sheets",
            "subformat": "csv",
            "files_list": [
                "csv_safeguarding"
            ]
        },
        "safeguarding_csv_list_remap": {
            "parent_sources": [],
            "format": "sheets",
            "subformat": "csv",
            "basepath": "csv",
            "files_list": [
                "safeguarding"
            ]
        },
        "safeguarding_xlsx_dict": {
            "parent_sources": [],
            "format": "sheets",
            "subformat": "xlsx",
            "files_dict": {
                "safeguarding": "excel_files/safeguarding crisis.xlsx"
            }
        },
        "safeguarding_xlsx_list_remap": {
            "parent_sources": [],
            "format": "sheets",
            "subformat": "xlsx",
            "files_list": [
                "xlsx_safeguarding"
            ]
        },
        "safeguarding_xlsx_list": {
            "parent_sources": [],
            "basepath": "excel_files",
            "format": "sheets",
            "subformat": "xlsx",
            "files_list": [
                "safeguarding crisis.xlsx"
            ]
        }
    },
    "steps": []
}

```