### PR TITLE
Download safeguarding files from Google Drive (optionally)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "packaging~=21.3",
     "rapidpro-abtesting @ git+https://github.com/IDEMSInternational/rapidpro_abtesting.git@master",
     "requests~=2.31",
-    "rpft @ git+https://github.com/IDEMSInternational/rapidpro-flow-toolkit.git@1.6.0",
+    "rpft @ git+https://github.com/IDEMSInternational/rapidpro-flow-toolkit.git@1.7.0",
 ]
 
 [project.scripts]

--- a/src/parenttext_pipeline/extract_keywords.py
+++ b/src/parenttext_pipeline/extract_keywords.py
@@ -16,9 +16,9 @@ def process_keywords(sources):
 
 
 def process_source(source):
-    input_file = source["path"]
+    input_file = source.get("location") or source["path"]
     language = source["key"]
-    book = openpyxl.load_workbook(input_file)
+    book = openpyxl.load_workbook(input_file, read_only=True)
     all_tables = {}
 
     for sheet in book.worksheets:


### PR DESCRIPTION
During the 'pull' phase, the safeguarding XLSX workbook can be downloaded via the Google Drive API. The workbook must be uploaded to Drive as an XLSX file. Once uploaded, grab the Drive file id (from the URL) and add it to the 'sources' configuration for safeguarding.

```json
"safeguarding": {
    "format": "safeguarding",
    "sources" : [
        {
            "key": "ara",
            "location": "1M9CgURmS433MuF1lwc4fMFYsmCJAUhE3"
        }
    ]
}
```

Note the key `location`, instead of `path`. Both `path` and `location` are usable, but only `location` will trigger a download from Drive. The `path` key should be considered deprecated and will be removed in a future release.

Resolves #143 