### PR TITLE
Modify type of LtpActivityModel.text to `list[str]`

### DIFF
--- a/src/parenttext_pipeline/models/parenttext_models.py
+++ b/src/parenttext_pipeline/models/parenttext_models.py
@@ -303,9 +303,9 @@ class OnboardingQuestionConfirmModel(DataRowModel):
 
 class LtpActivityModel(DataRowModel):
     name: str = ""
-    text: str = ""
-    act_type: list[str] = ["Active"]  # ???
-    act_age: list[int] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
+    text: list[str] = []
+    act_type: list[str] = ["Active"]
+    act_age: list[int] = list(range(0, 18))
     use_in_demo: str = ""
     attached_single_doc: str = ""
 


### PR DESCRIPTION
The text field of LtpActivityModel has type `str`, but there are cases where the field is defined as a string in sheets ([Crisis Palestine](https://docs.google.com/spreadsheets/d/1LxRmR5SS-5OZfiXlHzmg1yOsN2u33sgEexXj0I-W2js/edit?gid=793100372#gid=793100372)) and is expected to be treated as a list during processing.

This change requires an accompanying change in the ["ltp_activity" template](https://docs.google.com/spreadsheets/d/1hcH8pFdiHZN0UvZgyv3Zht9ARBTx-VXhNBI2o8L7fHU/edit?gid=460291043#gid=460291043) - row 2, "message_text" column, from `{{text}}` to `{@ text @}`.