### PR TITLE
Create Canto client and media asset downloader

### DIFF
--- a/docs/canto.md
+++ b/docs/canto.md
@@ -2,6 +2,11 @@
 
 ## Command line interface
 
+Ensure that:
+
+- there is a [JSON configuration file](#JSON) in the current working directory
+- the necessary [environment variables](#environment-variables) are set
+
 ```
 python -m parenttext.canto destination_dir
 ```
@@ -10,6 +15,8 @@ Where `destination_dir` is the root directory under which all assets will be dow
 
 
 ## Configuration
+
+### JSON
 
 Create a configuration file called 'config.json' in the root directory of the deployment repository. If 'config.json' already exists, the following JSON should be merged into it.
 ```json
@@ -59,8 +66,18 @@ The `storage` property describes the system holding the assets and the location 
 
 - `site_base_url`: location of the Canto server
 
+### Environment variables
+
 Secret information needs to be passed to the Canto server in order to log in, these are passed into the app via environment variables:
 
 - `CANTO_APP_ID`: ID generated when an API key is created in Canto
 - `CANTO_APP_SECRET`: secret generated when an API key is created in Canto
 - `CANTO_USER_ID`: user account that will be impersonated; should be the least privileged account able to download assets
+
+When running the CLI tool, these environment variables can be automatically read from a file called '.env' in the current working directory. The file should contain a single key value pair on each line, for example:
+
+```
+CANTO_APP_ID=app_id
+CANTO_APP_SECRET=secret
+CANTO_USER_ID=user_id
+```

--- a/docs/canto.md
+++ b/docs/canto.md
@@ -1,0 +1,66 @@
+# Download media assets from Canto
+
+## Command line interface
+
+```
+python -m parenttext.canto destination_dir
+```
+
+Where `destination_dir` is the root directory under which all assets will be downloaded and stored.
+
+
+## Configuration
+
+Create a configuration file called 'config.json' in the root directory of the deployment repository. If 'config.json' already exists, the following JSON should be merged into it.
+```json
+{
+    "sources": {
+        "media_assets": {
+            "mappings": {
+                "Language": {
+                    "Arabic": "ara"
+                },
+                "Caregiver Gender": {
+                    "F": "female",
+                    "M": "male"
+                }
+            },
+            "path_template": [
+                "{{ format | title }}",
+                "{{ (annotations['Caregiver Gender'] or '') | title }}",
+                "{{ (language or '') | title }}",
+                "{{ name }}"
+            ],
+            "storage": {
+                "system": "canto",
+                "location": "your folder id",
+                "annotations": {
+                    "site_base_url": "https://example.canto.com"
+                }
+            }
+        }
+    }
+}
+```
+
+The `mappings` property maps metadata values on assets from Canto to values that are required for a ParentText deployment. For example, any Canto asset with 'Arabic' as the value of the 'Language' property will have its value changed to 'ara'.
+
+The `path_template` property determines the directory structure of the downloaded assets on the local filesystem. Each item in the list represents a directory; the last item represents the name of the media asset file. An item can be a static value or a Jinja template. Templates have access to the following information about each asset:
+
+- `annotations`: transformed metadata properties from Canto
+- `format`: for example, 'video', 'audio', 'image'
+- `id`: Canto content id
+- `language`: three-letter language code
+- `name`: asset file name
+
+If any path element resolves to the empty string, that element will be ignored and the asset will be stored one level higher in the hierarchy. For example, if an asset would be stored under `audio/ara/name.m4a`, but the language metadata is not set, it would, instead, be stored under `audio/name.m4a`.
+
+The `storage` property describes the system holding the assets and the location of assets within the system. The `location` property should be set to the ID of the folder containing all the assets to be downloaded. Canto-specific settings are stored under `annotations`:
+
+- `site_base_url`: location of the Canto server
+
+Secret information needs to be passed to the Canto server in order to log in, these are passed into the app via environment variables:
+
+- `CANTO_APP_ID`: ID generated when an API key is created in Canto
+- `CANTO_APP_SECRET`: secret generated when an API key is created in Canto
+- `CANTO_USER_ID`: user account that will be impersonated; should be the least privileged account able to download assets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 dependencies = [
     "beautifulsoup4~=4.12",
     "packaging~=21.3",
+    "python-dotenv",
     "rapidpro-abtesting @ git+https://github.com/IDEMSInternational/rapidpro_abtesting.git@master",
     "requests~=2.31",
     "rpft @ git+https://github.com/IDEMSInternational/rapidpro-flow-toolkit.git@1.11.0",

--- a/src/parenttext/canto.py
+++ b/src/parenttext/canto.py
@@ -5,6 +5,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 import requests
+from dotenv import load_dotenv
 from jinja2 import ChainableUndefined, Environment
 
 
@@ -154,6 +155,7 @@ if __name__ == "__main__":
         config = json.load(fh)["sources"]["media_assets"]
 
     _env = Environment(undefined=ChainableUndefined)
+    load_dotenv()
 
     download_all(
         client=Canto(

--- a/src/parenttext/canto.py
+++ b/src/parenttext/canto.py
@@ -1,0 +1,169 @@
+import json
+import os
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import requests
+from jinja2 import ChainableUndefined, Environment
+
+
+@dataclass
+class MediaAsset:
+    format: str
+    id: str
+    language: str
+    name: str
+    annotations: dict = field(default_factory=dict)
+
+
+class Canto:
+
+    def __init__(
+        self,
+        app_id,
+        app_secret,
+        user_id,
+        site_base_url,
+        mappings={},
+    ):
+        self.app_id = app_id
+        self.app_secret = app_secret
+        self.user_id = user_id
+        self.oauth_base_url = (
+            "https://oauth." + site_base_url.split("//")[-1].split(".", 1)[-1]
+        )
+        self.site_base_url = site_base_url
+        self.mappings = mappings
+        self._token = None
+
+    @property
+    def token(self):
+        if not self._token:
+            self._token = self.authorize()
+
+        return self._token
+
+    def authorize(self):
+        return (
+            requests.request(
+                "POST",
+                f"{self.oauth_base_url}/oauth/api/oauth2/compatible/token",
+                data={
+                    "app_id": self.app_id,
+                    "app_secret": self.app_secret,
+                    "grant_type": "client_credentials",
+                    "user_id": self.user_id,
+                },
+            )
+            .json()
+            .get("access_token")
+        )
+
+    def tree(self, folder_id: str):
+        return (
+            requests.request(
+                method="GET",
+                url=f"{self.site_base_url}/api/v1/tree/{folder_id}",
+                headers={"Authorization": f"Bearer {self.token}"},
+            )
+            .json()
+            .get("results", [])
+        )
+
+    def album(self, album_id: str):
+        return (
+            requests.request(
+                method="GET",
+                url=f"{self.site_base_url}/api/v1/album/{album_id}",
+                headers={"Authorization": f"Bearer {self.token}"},
+            )
+            .json()
+            .get("results", [])
+        )
+
+    def download(self, scheme: str, content_id: str):
+        return requests.request(
+            method="GET",
+            url=f"{self.site_base_url}/api_binary/v1/{scheme}/{content_id}",
+            headers={"Authorization": f"Bearer {self.token}"},
+        ).content
+
+    def list_assets(self, folder_id: str):
+        for item in self.tree(folder_id):
+
+            if item["scheme"] == "album":
+
+                for content in self.album(item["id"]):
+                    annotations = transform_values(
+                        self.mappings,
+                        content.get("additional", {}),
+                    )
+                    asset = MediaAsset(
+                        annotations=annotations,
+                        format=content["scheme"],
+                        id=content["id"],
+                        language=annotations.get("Language", [""])[0],
+                        name=content["name"],
+                    )
+                    yield asset
+
+            if item["scheme"] == "folder":
+                self.list_assets(item["id"])
+
+
+def transform_values(mappings: dict, d: dict) -> dict:
+    transformed = {}
+
+    for k, v in d.items():
+        m = mappings.get(k) or {}
+
+        if isinstance(v, list):
+            transformed[k] = [m.get(item, item) for item in v]
+        else:
+            transformed[k] = m.get(v, v)
+
+    return transformed
+
+
+def asset_path(path_template, asset: MediaAsset):
+    return os.path.normpath(path_template.render(**asdict(asset)))
+
+
+def download_all(client, path_template, location: str, destination: str):
+    for asset in client.list_assets(location):
+        download(client, path_template, asset, destination)
+
+
+def download(client, path_template, asset: MediaAsset, destination):
+    dst = Path(destination) / asset_path(path_template, asset)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+
+    if dst.exists():
+        print(f"Download skipped, path={dst}")
+        return
+
+    with open(dst, "wb") as fh:
+        fh.write(client.download(asset.format, asset.id))
+
+    print(f"Download completed, path={dst}")
+
+
+if __name__ == "__main__":
+    with open("config.json", "r") as fh:
+        config = json.load(fh)["sources"]["media_assets"]
+
+    _env = Environment(undefined=ChainableUndefined)
+
+    download_all(
+        client=Canto(
+            app_id=os.getenv("CANTO_APP_ID"),
+            app_secret=os.getenv("CANTO_APP_SECRET"),
+            user_id=os.getenv("CANTO_USER_ID"),
+            site_base_url=config["storage"]["annotations"]["site_base_url"],
+            mappings=config.get("mappings") or {},
+        ),
+        path_template=_env.from_string(os.path.join(*config["path_template"])),
+        location=config["storage"]["location"],
+        destination=sys.argv[1],
+    )


### PR DESCRIPTION
```
python -m parenttext.canto destination_dir
```

Where `destination_dir` is the root directory under which all assets will be downloaded and stored. Requires configuration, see [docs/canto.md](docs/canto.md).