### PR TITLE
CLI option to output `.pot` files for all tag groups

### DIFF
--- a/src/parenttext_pipeline/cli.py
+++ b/src/parenttext_pipeline/cli.py
@@ -3,6 +3,7 @@ import argparse
 from packaging.version import Version
 
 import parenttext_pipeline.compile_flows
+import parenttext_pipeline.pot_output
 import parenttext_pipeline.pull_data
 from parenttext_pipeline import pipeline_version
 from parenttext_pipeline.configs import load_config
@@ -10,6 +11,7 @@ from parenttext_pipeline.configs import load_config
 OPERATIONS_MAP = {
     "pull_data": parenttext_pipeline.pull_data.run,
     "compile_flows": parenttext_pipeline.compile_flows.run,
+    "pot_output": parenttext_pipeline.pot_output.run,
 }
 
 

--- a/src/parenttext_pipeline/pot_output.py
+++ b/src/parenttext_pipeline/pot_output.py
@@ -1,0 +1,103 @@
+"""Adds a CLI option `pot_output`.
+This duplicates the base functionality of `compile_flows`, but runs a
+new version for each 'group' (e.g. "navigation") by overwriting the
+first step, then moves the output `.pot` file to the PLH preferred
+naming convention. Each tag group is processed in a `try...except`
+statement, so failures in one do not halt the flow.
+If the `.pot` file is produced, exception messages later in the pipeline
+are suppressed to simplify printout, if the renaming fails (due to the
+`.pot` file not being produced) the full traceback is printed for
+debugging of the sheets.
+"""
+
+import os
+import traceback
+from parenttext_pipeline import steps
+from parenttext_pipeline.common import (
+    clear_or_create_folder,
+    get_input_folder,
+    read_meta,
+    write_meta,
+)
+from parenttext_pipeline.compile_sources import compile_sources
+from parenttext_pipeline.compile_flows import apply_step
+from parenttext_pipeline.configs import CreateFlowsStepConfig
+
+
+def run(config):
+    clear_or_create_folder(config.outputpath)
+    clear_or_create_folder(config.temppath)
+
+    print("Compiling .pot files...")
+    config.sources = compile_sources(".", get_input_folder(config))
+
+    data = read_meta(config.inputpath)
+    meta = {"pull_timestamp": data["pull_timestamp"]}
+    write_meta(config, meta, config.outputpath)
+
+    failed_groups = []
+
+    # --- Iterate through the groups, running the pipeline for each ---
+
+    for group_name, group_tags in po_output_groups.items():
+
+        # Generate Override Steps Input Dict
+        step = {
+            "id": "create_flows",
+            "type": "create_flows",
+            "models_module": "models.parenttext_models",
+            "sources": ["flow_definitions"],
+            "tags": [],
+        }
+        step["tags"] = group_tags
+
+        # Apply new step
+        config.steps[0] = CreateFlowsStepConfig(**step)
+
+        # Run steps using code from compile_flows.py
+        try:
+            input_file = None
+            for step_num, step_config in enumerate(config.steps):
+                output_file = apply_step(config, step_config, step_num + 1, input_file)
+                print(
+                    f"Applied step {step_config.type}, result stored at {output_file}"
+                )
+                input_file = output_file
+
+            steps.split_rapidpro_json(config, output_file)
+            print("Result written to output folder")
+            steps.write_diffable(config, output_file)
+            print("Diffable written to output folder")
+        except Exception as e:
+            print(e)
+            # store traceback string
+            traceback_string = traceback.format_exc()
+
+        try:
+            # Move to the correct file
+            translator_output_folder = os.path.join(
+                config.outputpath, "send_to_translators"
+            )
+            current_file = os.path.join(
+                translator_output_folder, f"{config.flows_outputbasename}_crowdin.pot"
+            )
+            new_file = os.path.join(
+                translator_output_folder,
+                f"{config.sources['translation'].languages[0]['language']}_{group_name}.pot",
+            )
+            os.rename(current_file, new_file)
+        except FileNotFoundError:
+            failed_groups.append(group_name)
+            # If the translate files were not produced, print out the error for why
+            print(traceback_string)
+
+    print(f"Failed Groups: {failed_groups}")
+
+
+po_output_groups = {
+    "modules": [1, "module"],
+    "activities": [1, "ltp_activity"],
+    "onboarding": [1, "onboarding"],
+    "survey": [1, "survey"],
+    "navigation": [1, "delivery", 1, "menu", 1, "safeguarding"],
+}


### PR DESCRIPTION
Adds a CLI option `pot_output` which duplicates the base functionality of `compile_flows`, but runs a new version for each 'group' (e.g. "navigation") by overwriting the first step, then moves the output `.pot` file to the PLH preferred naming convention. Each tag group is processed in a `try...except` statement, so failures in one do not halt the flow.
If the `.pot` file is produced, exception messages later in the pipeline are suppressed to simplify printout, if the renaming fails (due to the `.pot` file not being produced) the full traceback is printed for debugging of the sheets.

For testing:

1. change `requirements.txt` to `parenttext_pipeline @ git+https://github.com/GabeBolton/parenttext-pipeline.git@sheet-check-automation`
2. reinstall `pip install -r requirements.txt`
3. change the pipeline version in config.json to `0.1.dev220+g688367` so it plays nice: `meta`>`"pipeline_version": "0.1.dev220+g688367f"`
4. run `python -m parenttext_pipeline.cli pot_output`

Long term this will enable deployers to check and debug their sheets themselves via GitHub Actions.