### PR TITLE
Allow compatible releases of the toolkit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "python-dotenv",
     "rapidpro-abtesting @ git+https://github.com/IDEMSInternational/rapidpro_abtesting.git@master",
     "requests~=2.31",
-    "rpft @ git+https://github.com/IDEMSInternational/rapidpro-flow-toolkit.git@1.15.0",
+    "rpft ~= 1.15",
 ]
 
 [project.scripts]


### PR DESCRIPTION
It used to be impossible to install a different version of 'rpft' than the one specified in this project. This change allows a later version to be installed at the level of a deployment, for example, which might allow a deployment to upgrade rpft before it is upgraded in the pipeline. This means that deployments might be able to use new toolkit features sooner.