### PR TITLE
Asset List Util, Placeholder Generation, & Media Ops Refactor

### DIFF
--- a/src/parenttext/firebase_tools.py
+++ b/src/parenttext/firebase_tools.py
@@ -144,9 +144,7 @@ class Firebase:
 
             if not up_to_date:
                 remote_version_number += 1
-                print(
-                    f"Bumping {vrs_posix} to {remote_version_number}"
-                )
+                print(f"Bumping {vrs_posix} to {remote_version_number}")
                 # Bump the remote version number
                 remote_version_folder = Path(f"{vrs_posix}{remote_version_number}")
                 self.upload_folder(
@@ -156,16 +154,14 @@ class Firebase:
                     dry_run=dry_run,
                 )
             else:
-                print(
-                    f"Hashes Matched for {vrs_posix}"
-                )
+                print(f"Hashes Matched for {vrs_posix}")
             current_versions[vrs_posix] = remote_version_number
         print("Current Versions")
         print(current_versions)
 
     def compare_hashes(self, local_filepath, bucket_name, file_path_in_storage):
         """Compares the MD5 hash of a local file with a Firebase Storage file.
-        
+
         Parameters
         ----------
         local_filepath : str
@@ -174,7 +170,7 @@ class Firebase:
             The name of the GCS bucket.
         file_path_in_storage : str
             The path to the file in Firebase Storage.
-        
+
         Returns
         -------
         bool
@@ -209,7 +205,7 @@ class Firebase:
 
     def upload_folder(self, bucket_name, local_base_path, gcs_base_path, dry_run=False):
         """Recursively uploads files from a local folder to a GCS bucket.
-        
+
         Parameters
         ----------
         bucket_name : str
@@ -221,7 +217,7 @@ class Firebase:
         dry_run : bool, optional
             If True, only prints the actions without uploading files.
             Defaults to False.
-        
+
         Returns
         -------
         None
@@ -254,6 +250,4 @@ class Firebase:
                     blob.make_public()
                 else:
                     print("Dry Run")
-                print(
-                    f"{file_path} -> gs://{bucket_name}/{destination_blob_name}"
-                )
+                print(f"{file_path} -> gs://{bucket_name}/{destination_blob_name}")

--- a/src/parenttext/media_ops.py
+++ b/src/parenttext/media_ops.py
@@ -20,29 +20,14 @@ from parenttext.canto import main as canto_main
 from parenttext.transcode import transcode as transcode_media, prepare as prepare_dir
 from parenttext.firebase_tools import Firebase
 
+from parenttext.referenced_assets import get_referenced_assets, get_parenttext_paths
+from parenttext.placeholder_gen import create_placeholder_files
 
-def main(
-    gcs_base_path: str | None = None,
-    project_id: str | None = None,
-    bucket_name: str | None = None,
-    dry_run: bool = False,
-):
 
-    try:
-        load_dotenv(".env")
-        gcs_base_path = gcs_base_path or getenv("DEPLOYMENT_ASSET_LOCATION")
-        project_id = project_id or getenv("GCS_PROJECT_ID")
-        bucket_name = bucket_name or getenv("GCS_BUCKET_NAME")
-    except:
-        raise FileNotFoundError("Must have a .env file in current working directory")
+env = {}
 
-    """Main function to orchestrate the entire workflow."""
-    print("=" * 50)
-    print("🚀 Starting Automated Media Processing Pipeline")
-    print("=" * 50)
 
-    print("🚀 Step 1: Starting Canto download...")
-
+def step_canto_download():
     if Path("canto").exists():
         # Copy all files into transcoded folder for images & comics
         shutil.copytree("canto", "old_canto")
@@ -50,15 +35,17 @@ def main(
         shutil.rmtree(Path("canto"))
 
     canto_main("canto")
-    print("✅ Step 1: Canto download complete.")
 
-    print("\n🚀 Step 2: Starting media transcoding...")
+
+def step_transcode():
+
+    transcode_path = env.get("MEDIA_OPS_TRANSCODE_FOLDER", "transcoded")
 
     # Copy all files into transcoded folder for images & comics
     # TODO: Handle compression of these folders in below loop with transcode
     try:
-        shutil.copytree("canto/image", "transcoded/image", dirs_exist_ok=True)
-        shutil.copytree("canto/comic", "transcoded/comic", dirs_exist_ok=True)
+        shutil.copytree("canto/image", f"{transcode_path}/image", dirs_exist_ok=True)
+        shutil.copytree("canto/comic", f"{transcode_path}/comic", dirs_exist_ok=True)
     except FileNotFoundError:
         print("  Warning: Image/Comic split not found, skipping")
 
@@ -71,26 +58,27 @@ def main(
             print("  Transcoding audio from video files.")
             raw_dir = "canto/voiceover/resourceType/video/"
         old_dir = f"old_{raw_dir}"
-        transcoded_dir = f"transcoded/voiceover/resourceType/{fmt}/"
+        transcoded_dir = f"{transcode_path}/voiceover/resourceType/{fmt}/"
         prepare_dir(transcoded_dir, wipe=False)  # make dir if doesn't exist
         transcode_media(raw_dir, transcoded_dir, old_src=old_dir, fmt=fmt)
 
     # remove old canto directory once it's no longer needed for change detection
     shutil.rmtree(Path("old_canto"))
-    print("✅ Step 2: Transcoding complete.")
+    
+    env["MEDIA_OPS_UPLOAD_FOLDER"] = transcode_path
 
-    print("\n🚀 Step 3: Starting upload to Firebase Storage...")
-    fb = Firebase(project_id=project_id)
+def step_firebase_versioned_upload():
+
+    transcoded_folder = env.get("MEDIA_OPS_UPLOAD_FOLDER", "transcoded")
+
+    fb = Firebase(project_id=env["GCS_PROJECTID"])
     fb.upload_new_version(
-        "transcoded", bucket_name, remote_directory=gcs_base_path, dry_run=dry_run
+        transcoded_folder, 
+        env["GCS_BUCKETNAME"], 
+        remote_directory=env["DEPLOYMENT_ASSET_LOCATION"], 
+        dry_run=env['dry_run']
     )
-    print("✅ Step 3: Firebase upload complete.")
 
-    print("\n" + "=" * 50)
-    print("🎉 Pipeline execution finished successfully!")
-    print("=" * 50)
-
-def test():
     print(
         "Now to change the version in RapidPro flows the user must:\n"
         "Update variables: RapidPro -> flows -> @ Globals\n"
@@ -98,8 +86,112 @@ def test():
         " -> Start -> select group 'enrolled' -> click start button"
     )
 
+
+def step_placeholder_gen():
+
+    rapidpro_file = env.get("RAPIDPRO_OUTPUT", "./output/parenttext_all.json")
+    placeholder_directory = env.get("MEDIA_OPS_PLACEHOLDER_FOLDER", "placeholder_assets")
+
+    with open("config.json", "r") as fh:
+        language_dicts = json.load(fh)["sources"]["translation"]["languages"]
+    language_list = [d["language"] for d in language_dicts]
+
+    gender_list = ["male", "female"] # Sexs will be replaced with genders soon...
+
+    path_dict = get_parenttext_paths(placeholder_directory, language_list, gender_list)
+
+    asset_list = get_referenced_assets(rapidpro_file, path_dict)
+
+    create_placeholder_files(asset_list)
+
+
+    env["MEDIA_OPS_UPLOAD_FOLDER"] = placeholder_directory
+
+
+step_dict = {
+    "canto_download":{
+        "fn": step_canto_download,
+        "start_msg": "Starting Canto download",
+        "end_msg": "Canto download complete",
+        "required_env": [
+            "CANTO_APP_ID"
+            "CANTO_APP_SECRET"
+            "CANTO_USER_ID"
+        ]
+    },
+    "transcode":{
+        "fn": step_transcode,
+        "start_msg": "Starting media transcoding",
+        "end_msg": "Transcoding complete",
+    },
+    "firebase_versioned_upload": {
+        "fn": step_firebase_versioned_upload,
+        "start_msg": "Starting upload to Firebase Storage",
+        "end_msg": "Firebase upload complete",
+        "required_env": [
+            "DEPLOYMENT_ASSET_LOCATION"
+            "GCS_PROJECTID"
+            "GCS_BUCKETNAME"
+        ]
+    },
+    "placeholder_gen": {
+        "fn": step_placeholder_gen
+    }
+
+}
+
+
+def main(
+    step_list,
+    dry_run: bool = False,
+):
+    env['dry_run'] = dry_run
+
+
+    """Main function to orchestrate the entire workflow."""
+    print("=" * 50)
+    print("🚀 Starting Automated Media Processing Pipeline")
+    print("=" * 50)
+
+    print("🚀 Step 1: Starting Canto download...")
+
+
+
+    for i, step_name in enumerate(step_list):
+        step = step_dict[step_name]
+        print(f"\n🚀 Step {i}: {step['end_msg']}")
+        step["fn"]()
+        print(f"✅ Step {i}: {step['end_msg']}")
+
+
+
+    print("\n" + "=" * 50)
+    print("🎉 Pipeline execution finished successfully!")
+    print("=" * 50)
+
+
+
+
+
+
+def assert_env_exists(step):
+
+    load_dotenv(".env")
+
+    failure_list = []
+    for e in step_dict[step]:
+        env[e] = getenv(e)
+        if env[e] is None:
+            failure_list.append(e)
+    
+    if len(failure_list) != 0:
+        raise Exception(
+            f"Required environment variables not found: {failure_list}"
+             "maybe you need a .env file?"
+        )
+
+
 if __name__ == "__main__":
-    # 1. Initialize the Argument Parser
     parser = argparse.ArgumentParser(
         description=(
             "A script to download assets from Canto, transcode them,"
@@ -107,22 +199,6 @@ if __name__ == "__main__":
         )
     )
 
-    # 2. Define Command-Line Arguments
-    parser.add_argument(
-        "--gcs_base_path",
-        type=str,
-        help="The base path in Google Cloud Storage for the upload (e.g., 'v1/en').",
-    )
-    parser.add_argument(
-        "--project-id",
-        type=str,
-        help="The target Firebase project ID.",
-    )
-    parser.add_argument(
-        "--bucket-name",
-        type=str,
-        help="The target Firebase Storage bucket name.",
-    )
     parser.add_argument(
         "-d",
         "--dry-run",
@@ -130,13 +206,20 @@ if __name__ == "__main__":
         help="Perform a dry run. Files will be processed, but not uploaded.",
     )
 
-    # 3. Parse the arguments from the command line
+    parser.add_argument(
+        "--steps",
+        action="store_true",
+        nargs="+",
+        default=['canto_download', "transcode", "firebase_versioned_upload"],
+        help=(
+            "Space separated list of steps. Defaults to versioned upload pipeline."
+            f"Options: {[step_name for step_name in step_dict.keys()]}"
+        ),
+    )
+
     args = parser.parse_args()
 
-    # 4. Call the main function with the parsed arguments
     main(
-        gcs_base_path=args.gcs_base_path,
-        project_id=args.project_id,
-        bucket_name=args.bucket_name,
+        step_list=args.steps,
         dry_run=args.dry_run,
     )

--- a/src/parenttext/media_ops.py
+++ b/src/parenttext/media_ops.py
@@ -126,9 +126,9 @@ step_dict = {
         "start_msg": "Starting Canto download",
         "end_msg": "Canto download complete",
         "required_env": [
-            "CANTO_APP_ID"
-            "CANTO_APP_SECRET"
-            "CANTO_USER_ID"
+            "CANTO_APP_ID",
+            "CANTO_APP_SECRET",
+            "CANTO_USER_ID",
         ]
     },
     "transcode":{
@@ -141,9 +141,9 @@ step_dict = {
         "start_msg": "Starting upload to Firebase Storage",
         "end_msg": "Firebase upload complete",
         "required_env": [
-            "DEPLOYMENT_ASSET_LOCATION"
-            "GCS_PROJECTID"
-            "GCS_BUCKETNAME"
+            "DEPLOYMENT_ASSET_LOCATION",
+            "GCS_PROJECTID",
+            "GCS_BUCKETNAME",
         ]
     },
     "firebase_non_versioned_upload": {
@@ -151,9 +151,9 @@ step_dict = {
         "start_msg": "Starting upload to Firebase Storage",
         "end_msg": "Firebase upload complete",
         "required_env": [
-            "DEPLOYMENT_ASSET_LOCATION"
-            "GCS_PROJECTID"
-            "GCS_BUCKETNAME"
+            "DEPLOYMENT_ASSET_LOCATION",
+            "GCS_PROJECTID",
+            "GCS_BUCKETNAME",
         ]
     },
     "placeholder_gen": {
@@ -203,9 +203,9 @@ def main(
 
     for i, step_name in enumerate(step_list):
         step = step_dict[step_name]
-        print(f"\n🚀 Step {i}: {step['end_msg']}")
+        print(f"\n🚀 Step {i+1}: {step['start_msg']}")
         step["fn"]()
-        print(f"✅ Step {i}: {step['end_msg']}")
+        print(f"✅ Step {i+1}: {step['end_msg']}")
 
     print("\n" + "=" * 50)
     print("🎉 Pipeline execution finished successfully!")

--- a/src/parenttext/media_ops.py
+++ b/src/parenttext/media_ops.py
@@ -64,8 +64,9 @@ def step_transcode():
 
     # remove old canto directory once it's no longer needed for change detection
     shutil.rmtree(Path("old_canto"))
-    
+
     env["MEDIA_OPS_UPLOAD_FOLDER"] = transcode_path
+
 
 def step_firebase_versioned_upload():
 
@@ -73,10 +74,10 @@ def step_firebase_versioned_upload():
 
     fb = Firebase(project_id=env["GCS_PROJECT_ID"])
     fb.upload_new_version(
-        source_directory=upload_folder, 
-        bucket_name=env["GCS_BUCKET_NAME"], 
-        remote_directory=env["DEPLOYMENT_ASSET_LOCATION"], 
-        dry_run=env['dry_run']
+        source_directory=upload_folder,
+        bucket_name=env["GCS_BUCKET_NAME"],
+        remote_directory=env["DEPLOYMENT_ASSET_LOCATION"],
+        dry_run=env["dry_run"],
     )
 
     print(
@@ -86,29 +87,32 @@ def step_firebase_versioned_upload():
         " -> Start -> select group 'enrolled' -> click start button"
     )
 
+
 def step_firebase_non_versioned_upload():
 
     upload_folder = env.get("MEDIA_OPS_UPLOAD_FOLDER", "transcoded")
 
     fb = Firebase(project_id=env["GCS_PROJECT_ID"])
     fb.upload_folder(
-        local_base_path=upload_folder, 
-        bucket_name=env["GCS_BUCKET_NAME"], 
-        gcs_base_path=env["DEPLOYMENT_ASSET_LOCATION"], 
-        dry_run=env['dry_run']
+        local_base_path=upload_folder,
+        bucket_name=env["GCS_BUCKET_NAME"],
+        gcs_base_path=env["DEPLOYMENT_ASSET_LOCATION"],
+        dry_run=env["dry_run"],
     )
 
 
 def step_placeholder_gen():
 
     rapidpro_file = env.get("RAPIDPRO_OUTPUT", "./output/parenttext_all.json")
-    placeholder_directory = env.get("MEDIA_OPS_PLACEHOLDER_FOLDER", "placeholder_assets")
+    placeholder_directory = env.get(
+        "MEDIA_OPS_PLACEHOLDER_FOLDER", "placeholder_assets"
+    )
 
     with open("config.json", "r") as fh:
         language_dicts = json.load(fh)["sources"]["translation"]["languages"]
     language_list = [d["language"] for d in language_dicts]
 
-    gender_list = ["male", "female"] # Sexs will be replaced with genders soon...
+    gender_list = ["male", "female"]  # Sexs will be replaced with genders soon...
 
     path_dict = get_parenttext_paths(placeholder_directory, language_list, gender_list)
 
@@ -116,12 +120,11 @@ def step_placeholder_gen():
 
     create_placeholder_files(asset_list)
 
-
     env["MEDIA_OPS_UPLOAD_FOLDER"] = placeholder_directory
 
 
 step_dict = {
-    "canto_download":{
+    "canto_download": {
         "fn": step_canto_download,
         "start_msg": "Starting Canto download",
         "end_msg": "Canto download complete",
@@ -129,9 +132,9 @@ step_dict = {
             "CANTO_APP_ID",
             "CANTO_APP_SECRET",
             "CANTO_USER_ID",
-        ]
+        ],
     },
-    "transcode":{
+    "transcode": {
         "fn": step_transcode,
         "start_msg": "Starting media transcoding",
         "end_msg": "Transcoding complete",
@@ -144,7 +147,7 @@ step_dict = {
             "DEPLOYMENT_ASSET_LOCATION",
             "GCS_PROJECT_ID",
             "GCS_BUCKET_NAME",
-        ]
+        ],
     },
     "firebase_non_versioned_upload": {
         "fn": step_firebase_non_versioned_upload,
@@ -154,14 +157,13 @@ step_dict = {
             "DEPLOYMENT_ASSET_LOCATION",
             "GCS_PROJECT_ID",
             "GCS_BUCKET_NAME",
-        ]
+        ],
     },
     "placeholder_gen": {
         "fn": step_placeholder_gen,
         "start_msg": "Creating directory of placeholder assets",
-        "end_msg": "Placeholders created"
-    }
-
+        "end_msg": "Placeholders created",
+    },
 }
 
 
@@ -173,18 +175,18 @@ def assert_env_exists(step_list):
     for step_name in step_list:
         step = step_dict[step_name]
         try:
-            for e in step['required_env']:
+            for e in step["required_env"]:
                 env[e] = getenv(e)
                 if env[e] is None:
                     failure_list.append(e)
         except KeyError:
             # It's okay if there are no required envs
             continue
-    
+
     if len(failure_list) != 0:
         raise Exception(
             f"Required environment variables not found: {failure_list}"
-             "maybe you need a .env file?"
+            "maybe you need a .env file?"
         )
 
 
@@ -192,7 +194,7 @@ def main(
     step_list,
     dry_run: bool = False,
 ):
-    env['dry_run'] = dry_run
+    env["dry_run"] = dry_run
 
     assert_env_exists(step_list)
 
@@ -231,7 +233,7 @@ if __name__ == "__main__":
         "--steps",
         type=str,
         nargs="+",
-        default=['canto_download', "transcode", "firebase_versioned_upload"],
+        default=["canto_download", "transcode", "firebase_versioned_upload"],
         help=(
             "Space separated list of steps. Defaults to versioned upload pipeline."
             f"\nOptions: {[step_name for step_name in step_dict.keys()]}"

--- a/src/parenttext/media_ops.py
+++ b/src/parenttext/media_ops.py
@@ -71,10 +71,10 @@ def step_firebase_versioned_upload():
 
     upload_folder = env.get("MEDIA_OPS_UPLOAD_FOLDER", "transcoded")
 
-    fb = Firebase(project_id=env["GCS_PROJECTID"])
+    fb = Firebase(project_id=env["GCS_PROJECT_ID"])
     fb.upload_new_version(
         source_directory=upload_folder, 
-        bucket_name=env["GCS_BUCKETNAME"], 
+        bucket_name=env["GCS_BUCKET_NAME"], 
         remote_directory=env["DEPLOYMENT_ASSET_LOCATION"], 
         dry_run=env['dry_run']
     )
@@ -90,10 +90,10 @@ def step_firebase_non_versioned_upload():
 
     upload_folder = env.get("MEDIA_OPS_UPLOAD_FOLDER", "transcoded")
 
-    fb = Firebase(project_id=env["GCS_PROJECTID"])
+    fb = Firebase(project_id=env["GCS_PROJECT_ID"])
     fb.upload_folder(
         local_base_path=upload_folder, 
-        bucket_name=env["GCS_BUCKETNAME"], 
+        bucket_name=env["GCS_BUCKET_NAME"], 
         gcs_base_path=env["DEPLOYMENT_ASSET_LOCATION"], 
         dry_run=env['dry_run']
     )
@@ -142,8 +142,8 @@ step_dict = {
         "end_msg": "Firebase upload complete",
         "required_env": [
             "DEPLOYMENT_ASSET_LOCATION",
-            "GCS_PROJECTID",
-            "GCS_BUCKETNAME",
+            "GCS_PROJECT_ID",
+            "GCS_BUCKET_NAME",
         ]
     },
     "firebase_non_versioned_upload": {
@@ -152,8 +152,8 @@ step_dict = {
         "end_msg": "Firebase upload complete",
         "required_env": [
             "DEPLOYMENT_ASSET_LOCATION",
-            "GCS_PROJECTID",
-            "GCS_BUCKETNAME",
+            "GCS_PROJECT_ID",
+            "GCS_BUCKET_NAME",
         ]
     },
     "placeholder_gen": {

--- a/src/parenttext/placeholder_gen.py
+++ b/src/parenttext/placeholder_gen.py
@@ -1,0 +1,64 @@
+import pathlib
+import shutil
+
+import pathlib
+import shutil
+
+
+def create_placeholder_files(file_paths: list[str]):
+    """
+    Creates placeholder files from a list of destination paths.
+
+    For each path (e.g., 'a/b/c.ext'), it verifies the base directory ('a')
+    exists. If so, it creates subdirectories ('a/b/') and copies a template
+    from './placeholders/ext.ext' to the destination path.
+
+    Args:
+        file_paths: A list of destination file paths.
+    """
+    placeholder_dir = pathlib.Path('placeholders')
+    if not placeholder_dir.is_dir():
+        print(f"⚠️  Placeholder directory not found: '{placeholder_dir}'. Aborting.")
+        return
+
+    for file_str in file_paths:
+        try:
+            dest_path = pathlib.Path(file_str)
+
+            # A valid path must have at least a base directory and a filename.
+            if len(dest_path.parts) < 2:
+                print(f"⚠️  Invalid path format: '{file_str}'. Skipping.")
+                continue
+
+            # Verify the base directory for the current file path exists.
+            base_dir = pathlib.Path(dest_path.parts[0])
+            if not base_dir.is_dir():
+                print(f"⚠️  Base directory '{base_dir}' not found. Skipping '{file_str}'.")
+                continue
+
+            # Create parent directories (e.g., 'a/b/' from 'a/b/c.ext').
+            dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+            # Determine the source placeholder from the file extension.
+            extension = dest_path.suffix
+            if not extension:
+                print(f"⚠️  No extension for '{dest_path}'. Skipping file.")
+                continue
+
+            # Construct the placeholder path (e.g., 'placeholders/jpg.jpg').
+            placeholder_name = f"{extension.lstrip('.')}{extension}"
+            source_path = placeholder_dir / placeholder_name
+
+            # Copy the placeholder if it exists.
+            if source_path.is_file():
+                shutil.copy(source_path, dest_path)
+                print(f"✅ Created '{dest_path}'")
+            else:
+                print(f"⚠️  Placeholder not found: '{source_path}'. Skipping.")
+
+        except Exception as e:
+            print(f"❌ Error processing '{file_str}': {e}")
+
+
+if __name__ == '__main__':
+    # --- Example Setup ---

--- a/src/parenttext/placeholder_gen.py
+++ b/src/parenttext/placeholder_gen.py
@@ -16,7 +16,7 @@ def create_placeholder_files(file_paths: list[str]):
     Args:
         file_paths: A list of destination file paths.
     """
-    placeholder_dir = pathlib.Path('placeholders')
+    placeholder_dir = pathlib.Path("placeholders")
     if not placeholder_dir.is_dir():
         print(f"⚠️  Placeholder directory not found: '{placeholder_dir}'. Aborting.")
         return
@@ -33,7 +33,9 @@ def create_placeholder_files(file_paths: list[str]):
             # Verify the base directory for the current file path exists.
             base_dir = pathlib.Path(dest_path.parts[0])
             if not base_dir.is_dir():
-                print(f"⚠️  Base directory '{base_dir}' not found. Skipping '{file_str}'.")
+                print(
+                    f"⚠️  Base directory '{base_dir}' not found. Skipping '{file_str}'."
+                )
                 continue
 
             # Create parent directories (e.g., 'a/b/' from 'a/b/c.ext').
@@ -53,7 +55,9 @@ def create_placeholder_files(file_paths: list[str]):
             if source_path.is_file():
                 shutil.copy(source_path, dest_path)
             else:
-                print(f"⚠️  Placeholder not found: '{source_path} for {dest_path}'. Skipping.")
+                print(
+                    f"⚠️  Placeholder not found: '{source_path} for {dest_path}'. Skipping."
+                )
 
         except Exception as e:
             print(f"❌ Error processing '{file_str}': {e}")

--- a/src/parenttext/placeholder_gen.py
+++ b/src/parenttext/placeholder_gen.py
@@ -52,9 +52,8 @@ def create_placeholder_files(file_paths: list[str]):
             # Copy the placeholder if it exists.
             if source_path.is_file():
                 shutil.copy(source_path, dest_path)
-                print(f"✅ Created '{dest_path}'")
             else:
-                print(f"⚠️  Placeholder not found: '{source_path}'. Skipping.")
+                print(f"⚠️  Placeholder not found: '{source_path} for {dest_path}'. Skipping.")
 
         except Exception as e:
             print(f"❌ Error processing '{file_str}': {e}")

--- a/src/parenttext/placeholder_gen.py
+++ b/src/parenttext/placeholder_gen.py
@@ -58,7 +58,3 @@ def create_placeholder_files(file_paths: list[str]):
 
         except Exception as e:
             print(f"❌ Error processing '{file_str}': {e}")
-
-
-if __name__ == '__main__':
-    # --- Example Setup ---

--- a/src/parenttext/referenced_assets.py
+++ b/src/parenttext/referenced_assets.py
@@ -1,0 +1,96 @@
+import json
+import re
+import itertools
+
+
+def _get_attachments(rapidpro_json):
+    for flow in rapidpro_json['flows']:
+        for node in flow['nodes']:
+            for action in node['actions']:
+                if 'attachments' in action.keys():
+                    if action['attachments'] != []:
+                        yield action['attachments']
+
+
+def process_attachment(attachment, path_dict, method) -> list:
+    match method:
+        case 'parenttext':
+            try:
+                file = re.findall(r'& "(.*)"\)', attachment)[0]
+                path = re.findall(r'fields\.(.*) &', attachment)[0]
+                return ['/'.join([p, file]) for p in path_dict[path]]
+            except IndexError:
+                pass
+    # If the method failed, print and return
+    print(f"Could not process attachment {attachment}")
+    return [attachment]
+
+
+def clean_path_dict(path_dict):
+    return {key: [i.rstrip('/') for i in val_ls] for key, val_ls in path_dict.items()}
+
+
+def get_referenced_assets(rapidpro_file, path_dict, 
+                          process_attachment_method=None):
+    process_attachment_method = process_attachment_method or 'parenttext'
+
+    path_dict = clean_path_dict(path_dict)
+
+    with open(rapidpro_file, "r", errors="ignore") as f:
+        rapidpro_json = json.load(f)
+
+    attachments = [item for sublist in _get_attachments(rapidpro_json) for item in sublist if sublist]
+    unique_attachments = list(set(attachments))
+
+    referenced_assets = []
+    for a in unique_attachments:
+        referenced_assets += process_attachment(a, path_dict, method=process_attachment_method)
+
+    return referenced_assets
+
+
+def get_parenttext_paths(root, language_list, gender_list, folder_versions=None):
+    _folder_versions = {
+        'comic': '',
+        'image': '',
+        'voiceover': ''
+    }
+    if folder_versions is not None:
+        _folder_versions.update(folder_versions)
+    versioned_folder = {k: ''.join([k,v]) for k, v in _folder_versions.items()}
+        
+    root = root.rstrip('/')
+    path_dict={
+        "path": [root],
+        "comic_path": ['/'.join([root, versioned_folder['comic']])],
+        "image_path": ['/'.join([root, versioned_folder['comic'], 'universal'])],
+    }
+
+    av_tails=[]
+    for (gender, language) in itertools.product(language_list, gender_list):
+        av_tails.append('/'.join(['gender', gender, 'language', language]))
+
+
+    path_dict["voiceover_video_path"] = []
+    path_dict["voiceover_audio_path"] = []
+    for tail in av_tails:
+        path_dict["voiceover_video_path"].append(
+            '/'.join([
+                root, 
+                versioned_folder['voiceover'],
+                'resourceType',
+                'video',
+                tail
+            ])
+        )
+        path_dict["voiceover_audio_path"].append(
+            '/'.join([
+                root, 
+                versioned_folder['voiceover'],
+                'resourceType',
+                'audio',
+                tail
+            ])
+        )
+    
+    return path_dict

--- a/src/parenttext/referenced_assets.py
+++ b/src/parenttext/referenced_assets.py
@@ -4,21 +4,21 @@ import itertools
 
 
 def _get_attachments(rapidpro_json):
-    for flow in rapidpro_json['flows']:
-        for node in flow['nodes']:
-            for action in node['actions']:
-                if 'attachments' in action.keys():
-                    if action['attachments'] != []:
-                        yield action['attachments']
+    for flow in rapidpro_json["flows"]:
+        for node in flow["nodes"]:
+            for action in node["actions"]:
+                if "attachments" in action.keys():
+                    if action["attachments"] != []:
+                        yield action["attachments"]
 
 
 def process_attachment(attachment, path_dict, method) -> list:
     match method:
-        case 'parenttext':
+        case "parenttext":
             try:
                 file = re.findall(r'& "(.*)"\)', attachment)[0]
-                path = re.findall(r'fields\.(.*) &', attachment)[0]
-                return ['/'.join([p, file]) for p in path_dict[path]]
+                path = re.findall(r"fields\.(.*) &", attachment)[0]
+                return ["/".join([p, file]) for p in path_dict[path]]
             except IndexError:
                 pass
     # If the method failed, print and return
@@ -27,70 +27,63 @@ def process_attachment(attachment, path_dict, method) -> list:
 
 
 def clean_path_dict(path_dict):
-    return {key: [i.rstrip('/') for i in val_ls] for key, val_ls in path_dict.items()}
+    return {key: [i.rstrip("/") for i in val_ls] for key, val_ls in path_dict.items()}
 
 
-def get_referenced_assets(rapidpro_file, path_dict, 
-                          process_attachment_method=None):
-    process_attachment_method = process_attachment_method or 'parenttext'
+def get_referenced_assets(rapidpro_file, path_dict, process_attachment_method=None):
+    process_attachment_method = process_attachment_method or "parenttext"
 
     path_dict = clean_path_dict(path_dict)
 
     with open(rapidpro_file, "r", errors="ignore") as f:
         rapidpro_json = json.load(f)
 
-    attachments = [item for sublist in _get_attachments(rapidpro_json) for item in sublist if sublist]
+    attachments = [
+        item
+        for sublist in _get_attachments(rapidpro_json)
+        for item in sublist
+        if sublist
+    ]
     unique_attachments = list(set(attachments))
 
     referenced_assets = []
     for a in unique_attachments:
-        referenced_assets += process_attachment(a, path_dict, method=process_attachment_method)
+        referenced_assets += process_attachment(
+            a, path_dict, method=process_attachment_method
+        )
 
     return referenced_assets
 
 
 def get_parenttext_paths(root, language_list, gender_list, folder_versions=None):
-    _folder_versions = {
-        'comic': '',
-        'image': '',
-        'voiceover': ''
-    }
+    _folder_versions = {"comic": "", "image": "", "voiceover": ""}
     if folder_versions is not None:
         _folder_versions.update(folder_versions)
-    versioned_folder = {k: ''.join([k,v]) for k, v in _folder_versions.items()}
-        
-    root = root.rstrip('/')
-    path_dict={
+    versioned_folder = {k: "".join([k, v]) for k, v in _folder_versions.items()}
+
+    root = root.rstrip("/")
+    path_dict = {
         "path": [root],
-        "comic_path": ['/'.join([root, versioned_folder['comic']])],
-        "image_path": ['/'.join([root, versioned_folder['comic'], 'universal'])],
+        "comic_path": ["/".join([root, versioned_folder["comic"]])],
+        "image_path": ["/".join([root, versioned_folder["comic"], "universal"])],
     }
 
-    av_tails=[]
-    for (gender, language) in itertools.product(language_list, gender_list):
-        av_tails.append('/'.join(['gender', gender, 'language', language]))
-
+    av_tails = []
+    for gender, language in itertools.product(language_list, gender_list):
+        av_tails.append("/".join(["gender", gender, "language", language]))
 
     path_dict["voiceover_video_path"] = []
     path_dict["voiceover_audio_path"] = []
     for tail in av_tails:
         path_dict["voiceover_video_path"].append(
-            '/'.join([
-                root, 
-                versioned_folder['voiceover'],
-                'resourceType',
-                'video',
-                tail
-            ])
+            "/".join(
+                [root, versioned_folder["voiceover"], "resourceType", "video", tail]
+            )
         )
         path_dict["voiceover_audio_path"].append(
-            '/'.join([
-                root, 
-                versioned_folder['voiceover'],
-                'resourceType',
-                'audio',
-                tail
-            ])
+            "/".join(
+                [root, versioned_folder["voiceover"], "resourceType", "audio", tail]
+            )
         )
-    
+
     return path_dict

--- a/src/parenttext/transcode.py
+++ b/src/parenttext/transcode.py
@@ -79,7 +79,7 @@ def source_has_changed(file_dst, source, old_file=None):
                 old_hash = hashlib.md5(f.read()).hexdigest()
             if new_hash == old_hash:
                 return False
-    return True            
+    return True
 
 
 def transcode(src, dst, old_src=None, fmt="video"):


### PR DESCRIPTION
Parse the `parenttext_all.json` output to identify all unique media attachments referenced.

Includes utility for generating the path options for parenttext. 

The #187 commits were cherry picked on top as well to clean up the commit history and make it squashable.

The `media_ops` refactor associated with the placeholder generation will make it much more flexible.

As the asset list utility transitions from an internal tool, to something we can use to provide clients with a list of assets they need to create, a user interface is likely to be needed, as will documentation on the use of that interface.